### PR TITLE
Fixed menu sorting and added optional menu parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,16 @@ Run the following commands inside your Hugo site folder:
     $ cd themes
     $ git clone https://github.com/sethmacleod/dimension.git
 
+Alternatively use git submodules in order to have a way to easily update the theme from the source in case you have your site in git as well.
+For this run the following commands inside your Hugo site folder:
+
+    $ git submodule add https://github.com/sethmacleod/dimension.git
+
+If you checkout your site from a repository which has this added as a submodule (e.g. if you are using CI to deploy), execute following commands or put them into a initgit.sh file in your repository which can be executed by your CI:
+
+    $ git submodule init
+    $ git submodule update
+
 ## Getting Started
 
 After installation, you will need to configure the config.toml file, change pictures, and write your pages.

--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ If you checkout your site from a repository which has this added as a submodule 
     $ git submodule init
     $ git submodule update
 
+In order to update all the existing submodules from their upstreams, you can either go into each submodule root folder and do the normal git pull or execute following command:
+
+    $ git submodule foreach git pull
+
 ## Getting Started
 
 After installation, you will need to configure the config.toml file, change pictures, and write your pages.

--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@ To create a new page, run the following command inside your Hugo sites:
 
 Change `your-page` to what you want to name the file. There are three variables that you can change: `title`, `weight`, and `draft`. Weight is set to 0 by default, so be sure to change it.
 
+As default, the title of the page will be taken as menu item. In case you have longer page titles, the menu may get distorted and you can set an additional parameter in the pages front matter to have a shorter menu name.
+Just set `menuname = "<Your Short Name>"` in that page and it will use this optional parameter. 
+
 You can also copy the pages from the exampleSite folder and modify those pages.
 
 ### Contact Form

--- a/exampleSite/content/formspree.md
+++ b/exampleSite/content/formspree.md
@@ -1,6 +1,7 @@
 +++
 title = "Formspree"
 weight = 60
+menuname = "Contact 2"
 draft = true
 +++
 

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -16,7 +16,7 @@
 						</div>
 						<nav>
 							<ul>
-								{{ range .Data.Pages }}
+								{{ range .Data.Pages.ByWeight }}
 								<li><a href="#{{ .File.BaseFileName }}">{{ .Title }}</a></li>
 								{{ end }}
 							</ul>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -17,7 +17,7 @@
 						<nav>
 							<ul>
 								{{ range .Data.Pages.ByWeight }}
-								<li><a href="#{{ .File.BaseFileName }}">{{ .Title }}</a></li>
+								<li><a href="#{{ .File.BaseFileName }}">{{ if .GetParam "menuname" }}{{ .GetParam "menuname" }}{{ else }}{{ .Title }}{{ end }}</a></li>
 								{{ end }}
 							</ul>
 						</nav>


### PR DESCRIPTION
I fixed menu sorting to not rely on the fact that sorting by weight stays hugos standard, I added it explicitly in the index.html template.
Additionally I had to introduce an optional site parameter in order to have the menu item name different from the title.
On my page I use longer titles and in one case I use a german word which is too long for the template and thus it just writes it over 2 cells. It is optional and behaves the way that if the parameter is not existing, it will use the title as default value.
This time I also edited the README to reflect that optional parameter and added the git submodule way to the install part as alternative.