### PR TITLE
introduce check for Site.Params.title

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -15,8 +15,12 @@
             </div>
             <div class="content">
               <div class="inner">
-                <h1>{{ .Site.Title | safeHTML }}</h1>
-                <p>{{ .Site.Params.description | safeHTML }}</p>
+                {{with .Site.Params.title}}
+                <h1>{{ . | safeHTML }}</h1>
+                {{end}}
+                {{with .Site.Params.description}}
+                <p>{{ . | safeHTML }}</p>
+                {{end}}
               </div>
             </div>
             <nav>


### PR DESCRIPTION
I built a site originally via Hugo v0.20 with Dimension. Time advanced, and I needed to make some updates -- but am now using v0.39. Upon making changes in my local instance, the title wasn't being rendered inside the <h1> anymore. After some digging, to solve I introduced the check for both Site.Params.title and Site.Params.description.