### PR TITLE
Crop logo images to circle

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -7,7 +7,7 @@
           <header id="header">
             <div class="logo">
               {{ with .Site.Params.logoimage }}
-              <img src="{{ . }}" width="100%" style="padding: 10px 10px 10px 10px;">
+              <img src="{{ . }}" width="100%" style="border-radius: 50%;">
             {{ end }}
             {{ with .Site.Params.logo }}            
               <span class="icon {{ . }}"></span>


### PR DESCRIPTION
logo image is handy, but by default it awkwardly puts in the rectangular image in a circle.  This change causes the image to be cropped to the circular shape instead 